### PR TITLE
[Feat#17] 사용자의 모든 프로젝트 불러오기 api

### DIFF
--- a/src/main/java/com/recnsa/cntime/controller/ProjectController.java
+++ b/src/main/java/com/recnsa/cntime/controller/ProjectController.java
@@ -2,6 +2,7 @@ package com.recnsa.cntime.controller;
 
 import com.recnsa.cntime.dto.project.ProjectCodeDTO;
 import com.recnsa.cntime.dto.project.ProjectColorDTO;
+import com.recnsa.cntime.dto.project.ProjectInfoListDTO;
 import com.recnsa.cntime.dto.project.ProjectNameDTO;
 import com.recnsa.cntime.global.common.SuccessResponse;
 import com.recnsa.cntime.service.ProjectService;
@@ -40,6 +41,7 @@ public class ProjectController {
 
     @GetMapping("/all")
     public ResponseEntity<SuccessResponse<?>> getAllProjectOfUser(@RequestHeader("Authorization") String jwtToken) {
-
+        ProjectInfoListDTO projectInfoListDTO = projectService.getAllProjectOfUser(jwtToken);
+        return null;
     }
 }

--- a/src/main/java/com/recnsa/cntime/controller/ProjectController.java
+++ b/src/main/java/com/recnsa/cntime/controller/ProjectController.java
@@ -37,4 +37,9 @@ public class ProjectController {
         return SuccessResponse.ok(color);
 
     }
+
+    @GetMapping("/all")
+    public ResponseEntity<SuccessResponse<?>> getAllProjectOfUser(@RequestHeader("Authorization") String jwtToken) {
+
+    }
 }

--- a/src/main/java/com/recnsa/cntime/controller/ProjectController.java
+++ b/src/main/java/com/recnsa/cntime/controller/ProjectController.java
@@ -42,6 +42,6 @@ public class ProjectController {
     @GetMapping("/all")
     public ResponseEntity<SuccessResponse<?>> getAllProjectOfUser(@RequestHeader("Authorization") String jwtToken) {
         ProjectInfoListDTO projectInfoListDTO = projectService.getAllProjectOfUser(jwtToken);
-        return null;
+        return SuccessResponse.ok(projectInfoListDTO);
     }
 }

--- a/src/main/java/com/recnsa/cntime/domain/Member.java
+++ b/src/main/java/com/recnsa/cntime/domain/Member.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name="member")
+@Table(name="member", uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id", "project_id"})})
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/java/com/recnsa/cntime/dto/project/ProjectInfoDTO.java
+++ b/src/main/java/com/recnsa/cntime/dto/project/ProjectInfoDTO.java
@@ -1,0 +1,19 @@
+package com.recnsa.cntime.dto.project;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProjectInfoDTO {
+    private UUID projectId;
+    private String projectName;
+    private Long numberOfMember;
+    private String color;
+}

--- a/src/main/java/com/recnsa/cntime/dto/project/ProjectInfoListDTO.java
+++ b/src/main/java/com/recnsa/cntime/dto/project/ProjectInfoListDTO.java
@@ -1,0 +1,14 @@
+package com.recnsa.cntime.dto.project;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectInfoListDTO {
+    private List<ProjectInfoDTO> projects;
+}

--- a/src/main/java/com/recnsa/cntime/repository/MemberRepository.java
+++ b/src/main/java/com/recnsa/cntime/repository/MemberRepository.java
@@ -5,8 +5,10 @@ import com.recnsa.cntime.domain.Project;
 import com.recnsa.cntime.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface MemberRepository extends JpaRepository<Member, UUID> {
     boolean existsByProjectAndUser(Project project, User user);
+    List<Member> findAllByUser(User user);
 }

--- a/src/main/java/com/recnsa/cntime/service/ProjectService.java
+++ b/src/main/java/com/recnsa/cntime/service/ProjectService.java
@@ -6,6 +6,7 @@ import com.recnsa.cntime.domain.User;
 import com.recnsa.cntime.dto.MemberIdDTO;
 import com.recnsa.cntime.dto.project.ProjectCodeDTO;
 import com.recnsa.cntime.dto.project.ProjectColorDTO;
+import com.recnsa.cntime.dto.project.ProjectInfoListDTO;
 import com.recnsa.cntime.dto.project.ProjectNameDTO;
 import com.recnsa.cntime.global.error.exception.ConflictException;
 import com.recnsa.cntime.global.error.exception.EntityNotFoundException;
@@ -20,6 +21,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -132,5 +134,14 @@ public class ProjectService {
                 .projectId(savedProject.getProjectId())
                 .color(savedProject.getColor())
                 .build();
+    }
+
+    public ProjectInfoListDTO getAllProjectOfUser(String jwtToken) {
+        UUID userId = extractUserId(getOnlyToken(jwtToken));
+        Optional<User> safeUser = userRepository.findById(userId);
+        if(safeUser.isEmpty()) throw new EntityNotFoundException();
+
+        List<Member> membersByUser = memberRepository.findAllByUser(safeUser.get());
+        return null;
     }
 }


### PR DESCRIPTION
## 이슈 번호  
closed #17 

## PR Type(Choose one)
- [X] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## Changed Branch
feat#17 -> dev

## Changes
사용자의 모든 프로젝트를 불러오는 api를 작성했습니다.
또한 member에 프로젝트와 유저가 모두 같은 로우가 여러개 추가되면 작성한 api에서 버그가 발생할 수 있다는 것을 발견해 유저와 프로젝트의 조합은 유니크하도록 설정했습니다.

## Screenshot
<img width="1108" alt="image" src="https://github.com/user-attachments/assets/8f96b385-a499-4fc1-a156-d5793cc5bfba">

## Note
